### PR TITLE
Added support for Tenda U12 Wifi Adapter (RTL8812AU based)

### DIFF
--- a/app/src/main/res/xml/usb_device_filter.xml
+++ b/app/src/main/res/xml/usb_device_filter.xml
@@ -24,4 +24,7 @@
     <usb-device
         product-id="17D2"
         vendor-id="0B05" /> <!-- Asus AC56 -->
+    <usb-device
+        product-id="0012"
+        vendor-id="2604" /> <!-- Tenda U12 -->
 </resources>


### PR DESCRIPTION
Added support for Tenda U12 Wifi Adapter which is based on RTL8812AU chipset