### PR TITLE
Fix path to keystore file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Build APK
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_PATH: ${{ github.workspace }}/pixelpilot.jks
         run: |
-          ./gradlew assembleRelease -Pandroid.injected.signing.store.file=pixelpilot.jks \
+          ./gradlew assembleRelease -Pandroid.injected.signing.store.file=$KEYSTORE_PATH \
           -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
           -Pandroid.injected.signing.key.alias=pixelpilot \
           -Pandroid.injected.signing.key.password=$KEYSTORE_PASSWORD


### PR DESCRIPTION
> Task :app:optimizeReleaseResources
FAILURE: Build failed with an exception.

* What went wrong:
> Task :app:packageRelease FAILED
178 actionable tasks: 178 executed
Configuration cache entry stored.
A problem was found with the configuration of task ':app:packageRelease' (type 'PackageApplication').
- Type 'com.android.build.gradle.tasks.PackageApplication' property 'signingConfigData$gradle_core.signingConfigData.storeFile' specifies file '/home/runner/work/PixelPilot/PixelPilot/app/pixelpilot.jks' which doesn't exist.

Reason: An input file was expected to be present but it doesn't exist.

    Possible solutions:
      1. Make sure the file exists before the task is called.
2. Make sure that the task which produces the file is declared as an input.

For more information, please refer to
https://docs.gradle.org/8.7/userguide/validation_problems.html#input_file_does_not_exist in the Gradle documentation.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.