### PR TITLE
add function to sync current Android time to VTX, so VTX can create c…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation(project(":app:mavlink"))
     implementation(project(":app:videonative"))
     implementation(project(":app:wfbngrtl8812"))
+    implementation(libs.jsch)
 
     implementation(libs.appcompat)
     implementation(libs.material)

--- a/app/src/main/java/com/openipc/pixelpilot/Uilities.java
+++ b/app/src/main/java/com/openipc/pixelpilot/Uilities.java
@@ -1,0 +1,40 @@
+package com.openipc.pixelpilot;
+
+import android.util.Log;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+
+public class Uilities {
+
+    public static boolean syncTimeToRemote(String sshHost, int sshPort, String sshUser, String sshPassword) {
+        try {
+            JSch jsch = new JSch();
+            Session session = jsch.getSession(sshUser, sshHost, sshPort);
+            session.setPassword(sshPassword);
+            session.setConfig("StrictHostKeyChecking", "no");
+            session.connect(3000);
+
+            long timestampSeconds = System.currentTimeMillis() / 1000;
+            String remoteCommand = "date -s @" + timestampSeconds + " && hwclock -w";
+
+            ChannelExec channel = (ChannelExec) session.openChannel("exec");
+            channel.setCommand(remoteCommand);
+            channel.connect();
+
+            while (!channel.isClosed()) {
+                Thread.sleep(100);
+            }
+
+            int exitStatus = channel.getExitStatus();
+            channel.disconnect();
+            session.disconnect();
+            return exitStatus == 0;
+
+        } catch (Exception e) {
+            Log.e("SSHTimeSync", "Error syncing time: " + e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/openipc/pixelpilot/VideoActivity.java
+++ b/app/src/main/java/com/openipc/pixelpilot/VideoActivity.java
@@ -542,6 +542,9 @@ public class VideoActivity extends AppCompatActivity implements IVideoParamsChan
     private void showSettingsMenu(View anchor) {
         PopupMenu popup = new PopupMenu(this, anchor);
 
+        // initialize settings
+        initializeSubMenu(popup);
+
         // VR submenu
         setupVRSubMenu(popup);
 
@@ -570,6 +573,24 @@ public class VideoActivity extends AppCompatActivity implements IVideoParamsChan
         setupHelpSubMenu(popup);
 
         popup.show();
+    }
+
+    /**
+     * Submenu for initial settings
+     */
+    private void initializeSubMenu(PopupMenu popup) {
+        SubMenu recording = popup.getMenu().addSubMenu("Initialize");
+        MenuItem syncTimeToRtx = recording.add("Sync time to RTX");
+
+        syncTimeToRtx.setOnMenuItemClickListener(item -> {
+            new Thread(() -> {
+                boolean success = Uilities.syncTimeToRemote("10.5.0.10", 22, "root", "12345");
+                runOnUiThread(() -> {
+                    Toast.makeText(this, success ? "Sync succeeded" : "Sync failed", Toast.LENGTH_SHORT).show();
+                });
+            }).start();
+            return true;
+        });
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.5.2"
 coreKtx = "1.13.1"
 appcompat = "1.7.0"
+jsch = "0.1.55"
 material = "1.12.0"
 constraintlayout = "2.1.4"
 mpandroidchartVersion = "3.1.0"
@@ -9,6 +10,7 @@ mpandroidchartVersion = "3.1.0"
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+jsch = { module = "com.jcraft:jsch", version.ref = "jsch" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 philjay-mpandroidchart = { module = "com.github.Philjay:mpandroidchart", version.ref = "mpandroidchartVersion" }


### PR DESCRIPTION
Since there is no battery in VTX, the time cannot be saved. Every time the FPV is powered on, the time will reset, causing VTX to repeatedly create the video folder and overwrite the previous videos. Add the function of synchronizing time from the mobile phone to VTX. After each FPV battery replacement, click to execute once to ensure the time in VTX is correct. I have placed it in the initialize submenu, which also makes it convenient to add other setting functions later