### PR TITLE
Add local network UDP packet forwarding 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ local.properties
 /app/videonative/compile_commands.json
 /app/wfbngrtl8812/compile_commands.json
 /compile_commands.json
+/tmp
+video.sdp

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ local.properties
 /compile_commands.json
 /tmp
 video.sdp
+plan.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ where (brace yourself) most things actually work.
 - [LiveVideo10ms](https://github.com/Consti10/LiveVideo10ms): excellent video decoder from [Consti10](https://github.com/Consti10) converted into a module.
 - [wfb-ng](https://github.com/svpcom/wfb-ng): library allowing the broadcast of the video feed over the air.
 
-The wfb-ng [gs.key](https://github.com/OpenIPC/PixelPilot/raw/main/app/src/main/assets/gs.key) is embedded in the app.
+The wfb-ng [gs.key](https://github.com/OpenIPC/PixelPilot/raw/master/app/src/main/assets/gs.key) is embedded in the app.
 The settings menu allows selecting a different key from your phone.
 
 Supported rtl8812au wifi adapter are listed [here](https://github.com/OpenIPC/PixelPilot/blob/master/app/src/main/res/xml/usb_device_filter.xml).

--- a/app/src/main/java/com/openipc/pixelpilot/VideoActivity.java
+++ b/app/src/main/java/com/openipc/pixelpilot/VideoActivity.java
@@ -568,6 +568,9 @@ public class VideoActivity extends AppCompatActivity implements IVideoParamsChan
         // Drone submenu
         setupDroneSubMenu(popup);
 
+        // UDP Forwarding submenu
+        setupUdpForwardingSubMenu(popup);
+
         // Help submenu
         setupHelpSubMenu(popup);
 
@@ -918,6 +921,88 @@ public class VideoActivity extends AppCompatActivity implements IVideoParamsChan
             showLoginCredentialsDialog();
             return true;
         });
+    }
+
+    private void setupUdpForwardingSubMenu(PopupMenu popup) {
+        SubMenu forwardMenu = popup.getMenu().addSubMenu("UDP Forwarding");
+
+        SharedPreferences prefs = getSharedPreferences("general", MODE_PRIVATE);
+        boolean enabled = prefs.getBoolean("forward_udp_enabled", false);
+        String ip = prefs.getString("forward_udp_ip", "192.168.1.100");
+        int port = prefs.getInt("forward_udp_port", 5600);
+
+        MenuItem enableItem = forwardMenu.add("Enable");
+        enableItem.setCheckable(true);
+        enableItem.setChecked(enabled);
+        enableItem.setOnMenuItemClickListener(item -> {
+            boolean newState = !item.isChecked();
+            item.setChecked(newState);
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putBoolean("forward_udp_enabled", newState);
+            editor.apply();
+            updateUdpForwardingState();
+            return true;
+        });
+
+        MenuItem configItem = forwardMenu.add("Config Target (" + ip + ":" + port + ")");
+        configItem.setOnMenuItemClickListener(item -> {
+            showUdpForwardingDialog();
+            return true;
+        });
+    }
+
+    private void showUdpForwardingDialog() {
+        SharedPreferences prefs = getSharedPreferences("general", MODE_PRIVATE);
+        String ip = prefs.getString("forward_udp_ip", "192.168.1.100");
+        int port = prefs.getInt("forward_udp_port", 5600);
+
+        android.widget.LinearLayout layout = new android.widget.LinearLayout(this);
+        layout.setOrientation(android.widget.LinearLayout.VERTICAL);
+        layout.setPadding(50, 30, 50, 30);
+
+        final android.widget.EditText ipEditText = new android.widget.EditText(this);
+        ipEditText.setHint("Destination IP Address");
+        ipEditText.setText(ip);
+        layout.addView(ipEditText);
+
+        final android.widget.EditText portEditText = new android.widget.EditText(this);
+        portEditText.setHint("Destination Port");
+        portEditText.setInputType(android.text.InputType.TYPE_CLASS_NUMBER);
+        portEditText.setText(String.valueOf(port));
+        layout.addView(portEditText);
+
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("UDP Forwarding Config")
+                .setView(layout)
+                .setPositiveButton("Save", (dialog, which) -> {
+                    String newIp = ipEditText.getText().toString().trim();
+                    String newPortStr = portEditText.getText().toString().trim();
+                    int newPort = 5600;
+                    try {
+                        newPort = Integer.parseInt(newPortStr);
+                    } catch (NumberFormatException ignored) {}
+
+                    SharedPreferences.Editor editor = prefs.edit();
+                    editor.putString("forward_udp_ip", newIp);
+                    editor.putInt("forward_udp_port", newPort);
+                    editor.apply();
+
+                    Toast.makeText(this, "Forwarding settings saved: " + newIp + ":" + newPort, Toast.LENGTH_SHORT).show();
+                    updateUdpForwardingState();
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void updateUdpForwardingState() {
+        SharedPreferences prefs = getSharedPreferences("general", MODE_PRIVATE);
+        boolean enabled = prefs.getBoolean("forward_udp_enabled", false);
+        String ip = prefs.getString("forward_udp_ip", "192.168.1.100");
+        int port = prefs.getInt("forward_udp_port", 5600);
+
+        if (videoPlayer != null) {
+            videoPlayer.setUdpForwarding(ip, port, enabled);
+        }
     }
 
     /**
@@ -1358,6 +1443,7 @@ public class VideoActivity extends AppCompatActivity implements IVideoParamsChan
 
         wfbLinkManager.startAdapters();
         videoPlayer.start();
+        updateUdpForwardingState();
         videoPlayer.startAudio();
 
         osdManager.restoreOSDConfig();

--- a/app/videonative/src/main/cpp/UdpReceiver.cpp
+++ b/app/videonative/src/main/cpp/UdpReceiver.cpp
@@ -131,6 +131,16 @@ void UDPReceiver::receiveFromUDPLoop()
         // ssize_t message_length = recv(mSocket, buff, (size_t) mBuffsize, MSG_WAITALL);
         if (message_length > 0)
         {  // else -1 was returned;timeout/No data received
+            // 1. Forward packet first (minimize latency)
+            {
+                std::lock_guard<std::mutex> lock(mForwardMutex);
+                if (mForwardEnabled)
+                {
+                    sendto(mSocket, buff->data(), message_length, 0, (struct sockaddr*) &mDestAddr, sizeof(mDestAddr));
+                }
+            }
+
+            // 2. Local processing
             onDataReceivedCallback(buff->data(), (size_t) message_length);
 
             nReceivedBytes += message_length;
@@ -161,4 +171,20 @@ void UDPReceiver::receiveFromUDPLoop()
 int UDPReceiver::getPort() const
 {
     return mPort;
+}
+
+void UDPReceiver::setForwarding(const std::string& ip, int port, bool enabled)
+{
+    std::lock_guard<std::mutex> lock(mForwardMutex);
+    mForwardIP = ip;
+    mForwardPort = port;
+    mForwardEnabled = enabled;
+
+    memset(&mDestAddr, 0, sizeof(mDestAddr));
+    mDestAddr.sin_family = AF_INET;
+    mDestAddr.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip.c_str(), &mDestAddr.sin_addr) <= 0)
+    {
+        mForwardEnabled = false;
+    }
 }

--- a/app/videonative/src/main/cpp/UdpReceiver.h
+++ b/app/videonative/src/main/cpp/UdpReceiver.h
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <iostream>
 #include <thread>
+#include <mutex>
 // Starts a new thread that continuously checks for new data on UDP port
 
 class UDPReceiver
@@ -64,6 +65,8 @@ class UDPReceiver
 
     int getPort() const;
 
+    void setForwarding(const std::string& ip, int port, bool enabled);
+
   private:
     void receiveFromUDPLoop();
 
@@ -84,6 +87,12 @@ class UDPReceiver
     // 65,507 bytes (65,535 − 8 byte UDP header − 20 byte IP header).
     static constexpr const size_t UDP_PACKET_MAX_SIZE = 65507;
     JavaVM*                       javaVm;
+
+    std::mutex                    mForwardMutex;
+    std::string                   mForwardIP      = "";
+    int                           mForwardPort    = 0;
+    bool                          mForwardEnabled = false;
+    struct sockaddr_in            mDestAddr;
 };
 
 #endif  // FPVUE_UDPRECEIVER_H

--- a/app/videonative/src/main/cpp/VideoPlayer.cpp
+++ b/app/videonative/src/main/cpp/VideoPlayer.cpp
@@ -172,6 +172,7 @@ void VideoPlayer::start(JNIEnv* env, jobject androidContext)
         -16,
         [this](const uint8_t* data, size_t data_length) { onNewRTPData(data, data_length); },
         WANTED_UDP_RCVBUF_SIZE);
+    mUDPReceiver->setForwarding(mForwardIP, mForwardPort, mForwardEnabled);
     mUDPReceiver->startReceiving();
 
     mUDSReceiver.release();
@@ -250,6 +251,17 @@ void VideoPlayer::stopDvr()
     stopProcessing();
 }
 
+void VideoPlayer::setForwarding(const std::string& ip, int port, bool enabled)
+{
+    mForwardIP = ip;
+    mForwardPort = port;
+    mForwardEnabled = enabled;
+    if (mUDPReceiver)
+    {
+        mUDPReceiver->setForwarding(ip, port, enabled);
+    }
+}
+
 //----------------------------------------------------JAVA
 // bindings---------------------------------------------------------------
 #define JNI_METHOD(return_type, method_name) \
@@ -291,6 +303,19 @@ extern "C"
     (JNIEnv* env, jclass jclass1, jlong videoPlayerN, jobject androidContext)
     {
         native(videoPlayerN)->stop(env, androidContext);
+    }
+
+    JNI_METHOD(void, nativeSetUdpForwarding)
+    (JNIEnv* env, jclass jclass1, jlong nativeInstance, jstring ipStr, jint port, jboolean enabled)
+    {
+        VideoPlayer* p = native(nativeInstance);
+        if (p)
+        {
+            const char* ip = env->GetStringUTFChars(ipStr, nullptr);
+            std::string ip_cpp(ip);
+            env->ReleaseStringUTFChars(ipStr, ip);
+            p->setForwarding(ip_cpp, port, enabled);
+        }
     }
 
     JNI_METHOD(void, nativeSetVideoSurface)

--- a/app/videonative/src/main/cpp/VideoPlayer.h
+++ b/app/videonative/src/main/cpp/VideoPlayer.h
@@ -52,6 +52,8 @@ class VideoPlayer
 
     bool isRecording() { return (get_time_ms() - last_dvr_write) <= 500; }
 
+    void setForwarding(const std::string& ip, int port, bool enabled);
+
   private:
     void onNewNALU(const NALU& nalu);
 
@@ -111,6 +113,10 @@ class VideoPlayer
     }
 
     void processQueue();
+
+    std::string mForwardIP = "";
+    int         mForwardPort = 0;
+    bool        mForwardEnabled = false;
 
   public:
     AudioDecoder                 audioDecoder;

--- a/app/videonative/src/main/java/com/openipc/videonative/VideoPlayer.java
+++ b/app/videonative/src/main/java/com/openipc/videonative/VideoPlayer.java
@@ -50,6 +50,8 @@ public class VideoPlayer implements IVideoParamsChanged {
 
     public static native void nativeSetVideoSurface(long nativeInstance, Surface surface, int index);
 
+    public static native void nativeSetUdpForwarding(long nativeInstance, String ip, int port, boolean enabled);
+
     public static native void nativeStartDvr(long nativeInstance, int fd, int fmp4_enabled);
 
     public static native void nativeStopDvr(long nativeInstance);
@@ -122,6 +124,11 @@ public class VideoPlayer implements IVideoParamsChanged {
 
     public boolean isRunning() {
         return timer != null;
+    }
+
+    public void setUdpForwarding(String ip, int port, boolean enabled) {
+        verifyApplicationThread();
+        nativeSetUdpForwarding(nativeVideoPlayer, ip, port, enabled);
     }
 
     public void startDvr(int fd, boolean enabled_fmp4) {


### PR DESCRIPTION
This PR implements the functionality to forward raw UDP video/audio packets received from an OpenIPC to a designated IP address and port in the local network.

Open settings in the app, and navigate to UDP Forwarding.
Click Config Target and input the destination PC's local IP address and port 5600.
Check the Enable option.
<img width="571" height="441" alt="image" src="https://github.com/user-attachments/assets/65ed1273-8a94-4e21-8923-948b0188c82b" />

Testing APK path: test_apks/app-debug.apk

Test video:
https://youtu.be/a2fov083c0g?si=efxaQjR1K8Gx4MSJ